### PR TITLE
at mysql2 0.4.0 got error

### DIFF
--- a/nata2.gemspec
+++ b/nata2.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'toml'
   spec.add_runtime_dependency 'sequel'
   spec.add_runtime_dependency 'sqlite3'
-  spec.add_runtime_dependency 'mysql2'
+  spec.add_runtime_dependency 'mysql2', '~> 0.3.20'
   spec.add_runtime_dependency 'ridgepole'
   spec.add_runtime_dependency 'focuslight-validator'
 end


### PR DESCRIPTION
## Enviroment

OS X 10.11.1 and CentOS6.7 x86_64
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-darwin14]

``` bash
bundle exec ridgepole -c '{ adapter: mysql2, database: nata2, username:USERNAME, password: PASSWORD, host: 127.0.0.1 }' --apply
/usr/local/lib/ruby/gems/2.2.0/gems/activerecord-4.2.4/lib/active_record/connection_adapters/connection_specification.rb:177:in `rescue in spec': Specified 'mysql2' for database adapter, but the gem is not loaded. Add `gem 'mysql2'` to your Gemfile (and ensure its version is at the minimum required by ActiveRecord). (Gem::LoadError)
    from /usr/local/lib/ruby/gems/2.2.0/gems/activerecord-4.2.4/lib/active_record/connection_adapters/connection_specification.rb:174:in `spec'
    from /usr/local/lib/ruby/gems/2.2.0/gems/activerecord-4.2.4/lib/active_record/connection_handling.rb:50:in `establish_connection'
    from /usr/local/lib/ruby/gems/2.2.0/gems/ridgepole-0.6.3/lib/ridgepole/client.rb:5:in `initialize'
    from /usr/local/lib/ruby/gems/2.2.0/gems/ridgepole-0.6.3/bin/ridgepole:138:in `new'
    from /usr/local/lib/ruby/gems/2.2.0/gems/ridgepole-0.6.3/bin/ridgepole:138:in `<top (required)>'
    from /usr/local/bin/ridgepole:23:in `load'
    from /usr/local/bin/ridgepole:23:in `<main>'
```

due to a bug in the mysql2 0.4.0
[mysql2 0.4.0 Gem::LoadError - fix #675](https://github.com/brianmario/mysql2/issues/675)
Resolved by downgrading to 0.3.20

``` bash
bundle exec ridgepole -c '{ adapter: mysql2, database: nata2, username: USERNAME, password: PASSWORD, host: 127.0.0.1 }' --apply
Apply `Schemafile`
-- create_table("bundles", {})
   -> 0.0329s
-- add_index("bundles", ["service_name", "host_name", "database_name"], {:name=>"bundles_dbname_index", :unique=>true})
   -> 0.0315s
-- create_table("explains", {})
   -> 0.0227s
-- create_table("slow_queries", {})
   -> 0.0286s
-- add_index("slow_queries", ["datetime"], {:name=>"slow_queries_datetime_index"})
   -> 0.0330s
-- add_index("slow_queries", ["period_per_hour"], {:name=>"slow_queries_period_per_hour_index"})
   -> 0.0381s
-- add_index("slow_queries", ["period_per_day"], {:name=>"slow_queries_period_per_day_index"})
   -> 0.0318s
```
